### PR TITLE
Removing alerts from profile page template

### DIFF
--- a/bookclub/templates/bookclub/profile_settings.html
+++ b/bookclub/templates/bookclub/profile_settings.html
@@ -10,14 +10,6 @@
                 <h2>Profile Settings</h2>
             </div>
             <div class="card-body">
-                {% if messages %}
-                {% for message in messages %}
-                <div class="alert alert-{{ message.tags }}">
-                    {{ message }}
-                </div>
-                {% endfor %}
-                {% endif %}
-
                 <form method="post">
                     {% csrf_token %}
 


### PR DESCRIPTION
Since profile_settings.html extends base.html, the same Django messages are being displayed twice - once in the base template and once in the profile settings template.

Resolves #16 