### PR TITLE
Update "Member Rating Patterns" table to include # of books selected and an avg of ratings for those selections

### DIFF
--- a/bookclub/templates/bookclub/includes/analytics/rating_distribution.html
+++ b/bookclub/templates/bookclub/includes/analytics/rating_distribution.html
@@ -3,7 +3,6 @@
         <h3 class="h5 mb-0">Rating Distribution</h3>
     </div>
     <div class="card-body">
-        <!-- Added data validation and fallback -->
         {% if rating_distribution %}
             <canvas id="ratingDistributionChart" height="200" 
                     data-distribution="{{ rating_distribution|join:"," }}"></canvas>
@@ -23,18 +22,34 @@
                 <thead>
                     <tr>
                         <th>Member</th>
-                        <th>Average Rating</th>
                         <th>Books Rated</th>
+                        <th>Avg Rating Given </th>
+                        <th>Books Picked</th>
+                        <th>Avg Rating Received</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for stat in member_rating_stats %}
                         <tr>
                             <td>{{ stat.user.username }}</td>
+                            <td>{{ stat.count }}</td>
                             <td>
                                 {% include "bookclub/includes/star_rating.html" with rating=stat.avg_rating|floatformat:2 small=True %}
                             </td>
-                            <td>{{ stat.count }}</td>
+                            <td>
+                                {% if stat.books_selected_count %}
+                                    {{ stat.books_selected_count }}
+                                {% else %}
+                                    0
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if stat.avg_selection_rating %}
+                                    {% include "bookclub/includes/star_rating.html" with rating=stat.avg_selection_rating|floatformat:2 small=True %}
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/bookclub/views/attribution_analytics.py
+++ b/bookclub/views/attribution_analytics.py
@@ -215,6 +215,39 @@ def attribution_analytics(request, group_id):
             "distribution": rating_distribution,
         }
 
+    member_pick_books = defaultdict(list)
+
+    for book in books:
+        if book.picked_by_id and not book.is_collective_pick:
+            member_pick_books[book.picked_by_id].append(book)
+
+    selection_rating_stats = {}    
+
+    for member in members:
+        picked_books = member_pick_books.get(member.id, [])
+        adjusted_book_avgs = []
+
+        for book in picked_books:
+            rating_data = book_ratings.get(book.id)
+            if not rating_data:
+                continue
+
+            user_ratings = rating_data.get("user_ratings", {})
+
+            non_picker_ratings = [
+                r["value"] for user_id, r in user_ratings.items()
+                if user_id != member.id
+            ]
+
+            if non_picker_ratings:
+                adjusted_book_avgs.append(mean(non_picker_ratings))
+
+        selection_rating_stats[member.id] = {
+            "books_selected_count": len(picked_books),
+            "avg_selection_rating": (
+                round(mean(adjusted_book_avgs), 2) if adjusted_book_avgs else None
+            ),
+        }
     # Calculate member rating statistics
     member_rating_stats = []
     for member_id, ratings in member_ratings.items():
@@ -228,6 +261,14 @@ def attribution_analytics(request, group_id):
                         "count": len(ratings),
                     }
                 )
+
+    for stat in member_rating_stats:
+        user_id = stat["user"].id
+        selection_data = selection_rating_stats.get(user_id, {})
+
+        stat["avg_selection_rating"] = selection_data.get("avg_selection_rating")
+        stat["books_selected_count"] = selection_data.get("books_selected_count", 0)
+ 
 
     # Sort member rating stats by count (descending)
     member_rating_stats.sort(key=lambda x: (-x["count"], -x["avg_rating"]))


### PR DESCRIPTION
blame chatgpt if this breaks anything

Adds selection-based rating metrics to the Member Rating table.

Adds "Books Selected (#)" column
Adds "Avg Rating Received" (excludes picker’s own rating)
Keeps star + numeric formatting consistent with existing ratings
Refactors backend to compute per-member selection stats

Tested locally with sample data. 